### PR TITLE
Fix #5: Crash when scan is cancelled on iOS 7.1.2/iPhone 4S.

### DIFF
--- a/iOS/src/MWBarcodeScanner/MWScannerViewController.m
+++ b/iOS/src/MWBarcodeScanner/MWScannerViewController.m
@@ -786,7 +786,6 @@ didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer
 - (void)stopScanning {
 	if (self.state == CAMERA_DECODING) {
 		self.state = CANCELLING;
-		return;
 	}
 	
 	[self revertToNormal];


### PR DESCRIPTION
Added the fix mentioned in #5
