### PR TITLE
Fix exception if scanner is closed

### DIFF
--- a/src/android/src/com/manateeworks/BarcodeScannerPlugin.java
+++ b/src/android/src/com/manateeworks/BarcodeScannerPlugin.java
@@ -1305,7 +1305,7 @@ public class BarcodeScannerPlugin extends CordovaPlugin implements SurfaceHolder
                 public void run() {
                     if (ScannerActivity.param_OverlayMode == ScannerActivity.OM_MW) {
                         MWOverlay.removeOverlay();
-                    } else if (ScannerActivity.param_OverlayMode == ScannerActivity.OM_IMAGE && overlayImage != null) {
+                    } else if (rlSurfaceContainer != null && ScannerActivity.param_OverlayMode == ScannerActivity.OM_IMAGE) {
                         rlSurfaceContainer.removeView(overlayImage);
                     }
                     CameraManager.get().stopPreview();


### PR DESCRIPTION
If the scanner is not running in continuous mode and the scanner is closed
manually in the callback then an Nullpointer exception was raised because
the rlSurfaceContainer was already null.